### PR TITLE
Fix broken link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To support this project, you can [donate to the developer](https://www.paypal.co
 
 ## Developer Instructions
 
-After downloading the source code and having installed all the [prerequesites for your system](https://tauri.studio/en/docs/getting-started/intro)
+After downloading the source code and having installed all the [prerequesites for your system](https://tauri.studio/en/docs/getting-started/prerequisites)
 
 Install dependencies:
 


### PR DESCRIPTION
The link to the Tauri documentation was broken, so I replaced it by a functioning one.